### PR TITLE
Enable Vercel deployment

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,2 @@
+import app from '../server/index.js';
+export default app;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/api/(.*)", "destination": "/api/index.js" }],
+  "functions": { "api/index.js": { "runtime": "nodejs18.x" } }
+}


### PR DESCRIPTION
## Summary
- export the Express app without listening on Vercel
- expose server via `api/index.js`
- add Vercel deployment config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854db98e0b88331b7cb74a3f0efd46a