### PR TITLE
Fix Vercel runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,6 @@
   "outputDirectory": "dist",
   "rewrites": [{ "source": "/api/(.*)", "destination": "/api/index.js" }],
   "functions": {
-    "api/index.js": { "runtime": "nodejs18.x" }
+    "api/index.js": { "runtime": "@vercel/node@18" }
   }
 }


### PR DESCRIPTION
## Summary
- update `vercel.json` runtime to use `@vercel/node@18`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854e2ad026c83318227d1561c5c0e57