### PR TITLE
Update Vercel runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "rewrites": [{ "source": "/api/(.*)", "destination": "/api/index.js" }],
   "functions": {
     "api/**/*.js": {
-      "runtime": "vercel/node@20.x"
+      "runtime": "vercel/node@20.0.0"
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,8 @@
   "outputDirectory": "dist",
   "rewrites": [{ "source": "/api/(.*)", "destination": "/api/index.js" }],
   "functions": {
-    "api/index.js": { "runtime": "nodejs18.x" }
+    "api/**/*.js": {
+      "runtime": "vercel/node@20.x"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- use `vercel/node@20.x` runtime for all functions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854e2ad026c83318227d1561c5c0e57